### PR TITLE
Fix: Changed README link to `fuse.js`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ A huge inspiration for me has been [excalidraw.com](http://excalidraw.com).
 - [React-pdf](https://react-pdf.org/)
 - [Comlink-loader](https://github.com/GoogleChromeLabs/comlink-loader)
 - [React window](https://github.com/bvaughn/react-window)
-- [Fuse.js](https://github.com/atlassian/react-beautiful-dnd)
+- [Fuse.js](https://fusejs.io/)
 - [Framer Motion](https://www.framer.com/motion/)
 - [Feather icons](https://feathericons.com/)
 


### PR DESCRIPTION
`fuse.js` link was pointed towards `React Beautiful dnd`, updated link to point to https://fusejs.io